### PR TITLE
Bring addon naming in line with Docker mods and themepark docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ http:
           # This currently only supports '4k-logo' and 'darker' addons. Future addons that follow a similar syntax will work as well.
           # For refernce: https://docs.theme-park.dev/themes/addons/
           addons:
-            - 4k-logo
+            - sonarr-4k-logo
     radarr-theme:
       plugin:
         themepark:
@@ -82,8 +82,8 @@ http:
 
           # Multiple addons can be included at the same time
           addons:
-            - darker
-            - 4k-logo
+            - radarr-darker
+            - radarr-4k-logo
 
   services:
     my-service:

--- a/themepark.go
+++ b/themepark.go
@@ -67,7 +67,17 @@ func (config *Config) getReplacementString() string {
 		if strings.HasPrefix(addon, config.App) {
 			stringBuilder.WriteString(fmt.Sprintf(addonFormat, config.BaseURL, config.App, addon, addon))
 		} else {
-			stringBuilder.WriteString(fmt.Sprintf(addonFormatLegacy, config.BaseURL, config.App, config.App, addon, config.App, addon))
+			stringBuilder.WriteString(
+				fmt.Sprintf(
+					addonFormatLegacy,
+					config.BaseURL,
+					config.App,
+					config.App,
+					addon,
+					config.App,
+					addon,
+				),
+			)
 		}
 	}
 

--- a/themepark.go
+++ b/themepark.go
@@ -48,6 +48,11 @@ const replFormat string = "<link " +
 	"type=\"text/css\" " +
 	"href=\"%s/css/base/%s/%s.css\">"
 
+const addonFormatLegacy string = "<link " +
+	"rel=\"stylesheet\" " +
+	"type=\"text/css\" " +
+	"href=\"%s/css/addons/%s/%s-%s/%s-%s.css\">"
+
 const addonFormat string = "<link " +
 	"rel=\"stylesheet\" " +
 	"type=\"text/css\" " +
@@ -59,7 +64,11 @@ func (config *Config) getReplacementString() string {
 	stringBuilder.WriteString(fmt.Sprintf(replFormat, config.BaseURL, config.App, config.Theme))
 
 	for _, addon := range config.Addons {
-		stringBuilder.WriteString(fmt.Sprintf(addonFormat, config.BaseURL, config.App, addon, addon))
+		if strings.HasPrefix(addon, config.App) {
+			stringBuilder.WriteString(fmt.Sprintf(addonFormat, config.BaseURL, config.App, addon, addon))
+		} else {
+			stringBuilder.WriteString(fmt.Sprintf(addonFormatLegacy, config.BaseURL, config.App, config.App, addon, config.App, addon))
+		}
 	}
 
 	stringBuilder.WriteString(config.Target)

--- a/themepark.go
+++ b/themepark.go
@@ -51,7 +51,7 @@ const replFormat string = "<link " +
 const addonFormat string = "<link " +
 	"rel=\"stylesheet\" " +
 	"type=\"text/css\" " +
-	"href=\"%s/css/addons/%s/%s-%s/%s-%s.css\">"
+	"href=\"%s/css/addons/%s/%s/%s.css\">"
 
 func (config *Config) getReplacementString() string {
 	var stringBuilder strings.Builder
@@ -59,7 +59,7 @@ func (config *Config) getReplacementString() string {
 	stringBuilder.WriteString(fmt.Sprintf(replFormat, config.BaseURL, config.App, config.Theme))
 
 	for _, addon := range config.Addons {
-		stringBuilder.WriteString(fmt.Sprintf(addonFormat, config.BaseURL, config.App, config.App, addon, config.App, addon))
+		stringBuilder.WriteString(fmt.Sprintf(addonFormat, config.BaseURL, config.App, addon, addon))
 	}
 
 	stringBuilder.WriteString(config.Target)

--- a/themepark_test.go
+++ b/themepark_test.go
@@ -191,6 +191,13 @@ func TestReplacementString(t *testing.T) {
 				"<link rel=\"stylesheet\" type=\"text/css\" href=\"https://theme-park.dev/css/addons/placeholder/placeholder-4k-logo/placeholder-4k-logo.css\">" +
 				"</head>",
 		},
+		{
+			desc:   "Nord placeholder Theme with 4k logo with placeholder name included",
+			config: Config{App: "placeholder", Theme: "nord", Addons: []string{"placeholder-4k-logo"}},
+			expected: "<link rel=\"stylesheet\" type=\"text/css\" href=\"https://theme-park.dev/css/base/placeholder/nord.css\">" +
+				"<link rel=\"stylesheet\" type=\"text/css\" href=\"https://theme-park.dev/css/addons/placeholder/placeholder-4k-logo/placeholder-4k-logo.css\">" +
+				"</head>",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {


### PR DESCRIPTION
This should change the current output of:
```html
<link rel="stylesheet" type="text/css" href="https://theme-park.dev/css/addons/readarr/readarr-readarr-alt-logo/readarr-readarr-alt-logo.css">
```
to the correct (when following themepark docs):
```html
<link rel="stylesheet" type="text/css" href="https://theme-park.dev/css/addons/readarr/readarr-alt-logo/readarr-alt-logo.css">
```
Not super familiar with Traefik plugin development so please do your own test of this.

The PR was made because your own documentation does not line up with the themepark docs: https://docs.theme-park.dev/themes/addons/sonarr/sonarr-4k-logo/#traefik
Which specify it like this:
```yaml
middlewares:
    sonarr-4k-logo:
        plugin:
            themepark:
                app: sonarr
                theme: base
                addons:
                    - sonarr-4k-logo
```
This would align both sides with how the Docker mod addons are specified. Feel free to close this if docs get updated instead, have notified the developer.